### PR TITLE
docs: standardize script name and update version to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Windows Update Manager v2
+# Windows Update Manager v3
 
 A **production-ready, menu-driven PowerShell tool** that wraps **PSWindowsUpdate** to make Windows Update management safer and easier: scan, install, hide/unhide, uninstall, export history, and run remote update jobs — with **sane defaults** and **audit-friendly logging**.
 
@@ -7,7 +7,7 @@ A **production-ready, menu-driven PowerShell tool** that wraps **PSWindowsUpdate
 ## 30-second quick start
 1) Run PowerShell as Admin (the script can auto-elevate):
 ```powershell
-.\WindowsUpdate-Manager_v2.ps1
+.\WindowsUpdate-Manager.ps1
 ```
 
 2) First run will guide you through setup (module/dependency checks + preferences).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,14 +1,14 @@
-# Windows Update Manager v2.0 - User Guide
+# Windows Update Manager v3.0 - User Guide
 
 **Author:** Ghostwheel
-**Version:** 2.0.0
+**Version:** 3.0.0
 **Created:** 2026-01-19
 
 ---
 
 ## Overview
 
-Windows Update Manager v2 is a professional, production-ready PowerShell script that provides comprehensive Windows Update management through an intuitive menu-driven interface. This enhanced version includes automatic dependency management, system safety features, and advanced configuration options.
+Windows Update Manager v3 is a professional, production-ready PowerShell script that provides comprehensive Windows Update management through an intuitive menu-driven interface. This enhanced version includes automatic dependency management, system safety features, and advanced configuration options.
 
 ---
 
@@ -77,7 +77,7 @@ Windows Update Manager v2 is a professional, production-ready PowerShell script 
 ### First Run
 
 1. **Right-click** the script and select "Run with PowerShell"
-   - Or open PowerShell and run: `.\WindowsUpdate-Manager_v2.ps1`
+   - Or open PowerShell and run: `.\WindowsUpdate-Manager.ps1`
 
 2. The script will:
    - Check for Administrator privileges and **elevate automatically**
@@ -270,7 +270,7 @@ Logs all errors with timestamps and exception details.
 ## 🔧 Command-Line Parameters
 
 ```powershell
-.\WindowsUpdate-Manager_v2.ps1 [parameters]
+.\WindowsUpdate-Manager.ps1 [parameters]
 ```
 
 ### Available Parameters
@@ -299,16 +299,16 @@ Logs all errors with timestamps and exception details.
 
 ```powershell
 # Run with default settings
-.\WindowsUpdate-Manager_v2.ps1
+.\WindowsUpdate-Manager.ps1
 
 # Run without elevation (already admin)
-.\WindowsUpdate-Manager_v2.ps1 -NoElevation
+.\WindowsUpdate-Manager.ps1 -NoElevation
 
 # Custom config and log paths
-.\WindowsUpdate-Manager_v2.ps1 -ConfigPath "C:\Config\wu.json" -LogPath "C:\Logs\wu.log"
+.\WindowsUpdate-Manager.ps1 -ConfigPath "C:\Config\wu.json" -LogPath "C:\Logs\wu.log"
 
 # Skip dependency checks (faster startup)
-.\WindowsUpdate-Manager_v2.ps1 -SkipDependencyCheck
+.\WindowsUpdate-Manager.ps1 -SkipDependencyCheck
 ```
 
 ---
@@ -441,7 +441,7 @@ Logs all errors with timestamps and exception details.
 
 If you're upgrading from the original script:
 
-### What's New in v2
+### What's New in v3
 - Automatic dependency management
 - Enhanced color-coded UI
 - Pre-flight system checks
@@ -453,7 +453,7 @@ If you're upgrading from the original script:
 - PowerShell 7.5+ installation option
 
 ### Configuration Migration
-- v2 will create a new config file
+- v3 will create a new config file
 - Old settings can be manually re-entered via Settings menu
 - No data loss - old config is not modified
 
@@ -467,7 +467,7 @@ If you're upgrading from the original script:
 - Review transcript logs if logging is enabled
 
 ### Documentation
-- Built-in help: `Get-Help .\WindowsUpdate-Manager_v2.ps1 -Full`
+- Built-in help: `Get-Help .\WindowsUpdate-Manager.ps1 -Full`
 - PSWindowsUpdate docs: https://www.powershellgallery.com/packages/PSWindowsUpdate
 
 ---
@@ -506,6 +506,6 @@ This script is provided "as-is" without warranty of any kind. Use at your own ri
 
 ---
 
-**Enjoy professional Windows Update management with WindowsUpdate-Manager v2!**
+**Enjoy professional Windows Update management with WindowsUpdate-Manager v3!**
 
 For questions or issues, please refer to the error logs or enable verbose mode for detailed diagnostics.

--- a/WindowsUpdate-Manager.ps1
+++ b/WindowsUpdate-Manager.ps1
@@ -42,7 +42,7 @@
     - Customizable logging options
 
 .NOTES
-  File Name      : WindowsUpdate-Manager_v3.ps1
+  File Name      : WindowsUpdate-Manager.ps1
   Author         : Ghostwheel
   Version        : 3.0.0
   Created        : 2026-01-19
@@ -82,15 +82,15 @@
   Minimizes prompts for fully automated operation. Use with caution.
 
 .EXAMPLE
-  .\WindowsUpdate-Manager_v3.ps1
+  .\WindowsUpdate-Manager.ps1
   Runs the script with default settings and auto-elevation.
 
 .EXAMPLE
-  .\WindowsUpdate-Manager_v3.ps1 -NoElevation -ConfigPath "C:\Config\wu.json"
+  .\WindowsUpdate-Manager.ps1 -NoElevation -ConfigPath "C:\Config\wu.json"
   Runs without elevation using a custom configuration file path.
 
 .EXAMPLE
-  .\WindowsUpdate-Manager_v3.ps1 -LogPath "C:\Logs\WU.log"
+  .\WindowsUpdate-Manager.ps1 -LogPath "C:\Logs\WU.log"
   Runs with logging enabled to a specific path.
 #>
 


### PR DESCRIPTION
Updated script name references from `WindowsUpdate-Manager_v2.ps1` and `WindowsUpdate-Manager_v3.ps1` to `WindowsUpdate-Manager.ps1` across `README.md`, `USER_GUIDE.md`, and `WindowsUpdate-Manager.ps1` examples. Updated version mentions from `v2` / `2.0` to `v3` / `3.0.0` in documentation to align with the actual version in the script.

---
*PR created automatically by Jules for task [5312635128911451866](https://jules.google.com/task/5312635128911451866) started by @GhostwheeI*