### PR TITLE
Fix Pause to Pause-UI in script and update docs for v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Windows Update Manager v2
+# Windows Update Manager v3
 
-A **production-ready, menu-driven PowerShell tool** that wraps **PSWindowsUpdate** to make Windows Update management safer and easier: scan, install, hide/unhide, uninstall, export history, and run remote update jobs — with **sane defaults** and **audit-friendly logging**.
+A **production-ready, menu-driven PowerShell tool** that wraps **PSWindowsUpdate** to make Windows Update management safer and easier: scan, install, hide/unhide, uninstall, export history, and run remote update jobs — with **sane defaults**, **audit-friendly logging**, and **stunning visuals**.
 
 > ⭐ If this saved you time, starring the repo helps prioritize maintenance and improvements.
 
 ## 30-second quick start
 1) Run PowerShell as Admin (the script can auto-elevate):
 ```powershell
-.\WindowsUpdate-Manager_v2.ps1
+.\WindowsUpdate-Manager.ps1
 ```
 
 2) First run will guide you through setup (module/dependency checks + preferences).
@@ -21,6 +21,14 @@ A **production-ready, menu-driven PowerShell tool** that wraps **PSWindowsUpdate
 - Generate a compliance report
 - Run remote installs via Invoke-WUJob (SYSTEM scheduled task)
 
+## New in v3: Visual Enhancements
+- **ASCII art titles** with multiple styles (Standard, Slant, Cyberpunk)
+- **Color gradients and 24-bit RGB support** (PowerShell 7.5+)
+- **Sound effects** for key actions (configurable)
+- **Responsive layout** that adapts to your console size
+- **Enhanced box-drawing characters** for professional borders
+- **Advanced status displays** with intuitive visual indicators
+
 ## Who this is for
 - Sysadmins who want a repeatable update workflow
 - Helpdesk/junior staff who need guardrails (menus + confirmations)
@@ -28,7 +36,7 @@ A **production-ready, menu-driven PowerShell tool** that wraps **PSWindowsUpdate
 - Environments where update actions must be logged/auditable
 
 ## Documentation
-- Full user guide: **docs/USER_GUIDE.md**
+- Full user guide: **USER_GUIDE.md**
 
 ## Safety
 Windows Updates can reboot systems and remove updates. Test in non-production first. Use maintenance windows in server environments.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,14 +1,14 @@
-# Windows Update Manager v2.0 - User Guide
+# Windows Update Manager v3.0 - User Guide
 
 **Author:** Ghostwheel
-**Version:** 2.0.0
+**Version:** 3.0.0
 **Created:** 2026-01-19
 
 ---
 
 ## Overview
 
-Windows Update Manager v2 is a professional, production-ready PowerShell script that provides comprehensive Windows Update management through an intuitive menu-driven interface. This enhanced version includes automatic dependency management, system safety features, and advanced configuration options.
+Windows Update Manager v3 is a professional, production-ready PowerShell script that provides comprehensive Windows Update management through an intuitive menu-driven interface. This enhanced version includes automatic dependency management, system safety features, advanced configuration options, and stunning visual enhancements.
 
 ---
 
@@ -21,11 +21,13 @@ Windows Update Manager v2 is a professional, production-ready PowerShell script 
 - ✅ **PowerShell 7.5+ installation** offering with clear benefits explanation
 - ✅ **Intelligent fallback** to Windows PowerShell 5.1 if user declines upgrade
 
-### Enhanced User Interface
-- 🎨 **Color-coded messages** (Info: Cyan, Success: Green, Warning: Yellow, Error: Red)
-- 📊 **Status indicators** (✓ Success, ✗ Error, ⚠ Warning, ℹ Info)
+### Enhanced User Interface (NEW in v3)
+- 🎨 **ASCII art titles** with multiple styles (Standard, Slant, Cyberpunk)
+- 🌈 **Color gradients** and 24-bit RGB support (PS7+)
+- 🔊 **Sound effects** for key actions
+- 📱 **Responsive layout** that adapts to console size
+- 📊 **Enhanced box-drawing characters** for professional borders
 - 📈 **Progress tracking** for long operations
-- 🖥️ **Professional banner** and menu system
 - 👁️ **Visual elevation indicator** (shows when running as Administrator)
 
 ### Safety Features
@@ -62,7 +64,8 @@ Windows Update Manager v2 is a professional, production-ready PowerShell script 
 - Internet connectivity for updates
 
 ### Recommended
-- PowerShell 7.5 or later (script will offer to install)
+- PowerShell 7.5 or later (script will offer to install for the best visual experience)
+- Terminal with ANSI escape sequence support (Windows Terminal, PS7+)
 - 10GB+ free disk space
 - Active Windows Update service
 
@@ -77,7 +80,7 @@ Windows Update Manager v2 is a professional, production-ready PowerShell script 
 ### First Run
 
 1. **Right-click** the script and select "Run with PowerShell"
-   - Or open PowerShell and run: `.\WindowsUpdate-Manager_v2.ps1`
+   - Or open PowerShell and run: `.\WindowsUpdate-Manager.ps1`
 
 2. The script will:
    - Check for Administrator privileges and **elevate automatically**
@@ -100,6 +103,10 @@ On first run, you'll be asked to configure:
 
 3. **Create Restore Point**
    - Whether to create system restore points before installing updates (Recommended)
+
+4. **Visual Preferences** (NEW in v3)
+   - Enable sound effects
+   - Enable color gradients (PS7+ only)
 
 ---
 
@@ -232,7 +239,27 @@ The script stores configuration in JSON format at:
   "TargetComputers": [],
   "CreateRestorePoint": true,
   "ExcludedKBs": [],
-  "AutoAcceptEULA": false
+  "AutoAcceptEULA": false,
+  "Visual": {
+    "AsciiArtStyle": "Cyberpunk",
+    "EnableAnimations": true,
+    "EnableSounds": false,
+    "AnimationSpeed": "Normal",
+    "ColorTheme": "Default",
+    "ShowTransitions": false,
+    "BorderStyle": "Double",
+    "ShowLiveDashboard": false,
+    "EnableGradients": true,
+    "PerformanceMode": false
+  },
+  "Sounds": {
+    "Startup": false,
+    "Success": false,
+    "Error": false,
+    "Warning": false,
+    "Complete": false,
+    "MenuClick": false
+  }
 }
 ```
 
@@ -244,6 +271,8 @@ The script stores configuration in JSON format at:
 - **CreateRestorePoint**: Create system restore point before updates
 - **ExcludedKBs**: Array of KB numbers to exclude (hidden updates)
 - **AutoAcceptEULA**: Automatically accept EULAs (use with caution)
+- **Visual**: Settings for v3 visual enhancements
+- **Sounds**: Settings for v3 sound effects
 
 ---
 
@@ -270,7 +299,7 @@ Logs all errors with timestamps and exception details.
 ## 🔧 Command-Line Parameters
 
 ```powershell
-.\WindowsUpdate-Manager_v2.ps1 [parameters]
+.\WindowsUpdate-Manager.ps1 [parameters]
 ```
 
 ### Available Parameters
@@ -299,16 +328,16 @@ Logs all errors with timestamps and exception details.
 
 ```powershell
 # Run with default settings
-.\WindowsUpdate-Manager_v2.ps1
+.\WindowsUpdate-Manager.ps1
 
 # Run without elevation (already admin)
-.\WindowsUpdate-Manager_v2.ps1 -NoElevation
+.\WindowsUpdate-Manager.ps1 -NoElevation
 
 # Custom config and log paths
-.\WindowsUpdate-Manager_v2.ps1 -ConfigPath "C:\Config\wu.json" -LogPath "C:\Logs\wu.log"
+.\WindowsUpdate-Manager.ps1 -ConfigPath "C:\Config\wu.json" -LogPath "C:\Logs\wu.log"
 
 # Skip dependency checks (faster startup)
-.\WindowsUpdate-Manager_v2.ps1 -SkipDependencyCheck
+.\WindowsUpdate-Manager.ps1 -SkipDependencyCheck
 ```
 
 ---
@@ -437,25 +466,20 @@ Logs all errors with timestamps and exception details.
 
 ---
 
-## 🔄 Upgrade from v1
+## 🔄 Upgrade from v2
 
-If you're upgrading from the original script:
+If you're upgrading from v2:
 
-### What's New in v2
-- Automatic dependency management
-- Enhanced color-coded UI
-- Pre-flight system checks
-- System restore point creation
-- KB exclusion list
-- Compliance reporting
-- Improved error handling and logging
-- First-run configuration wizard
-- PowerShell 7.5+ installation option
+### What's New in v3
+- ASCII art titles and visual enhancements
+- Color gradients (PS7+)
+- Sound effects
+- Responsive layout that auto-sizes to fit the menu
+- Additional box-drawing visual polish
 
 ### Configuration Migration
-- v2 will create a new config file
-- Old settings can be manually re-entered via Settings menu
-- No data loss - old config is not modified
+- v3 will use your existing config file and automatically add the new Visual and Sounds settings sections.
+- No data loss - old config is preserved.
 
 ---
 
@@ -467,7 +491,7 @@ If you're upgrading from the original script:
 - Review transcript logs if logging is enabled
 
 ### Documentation
-- Built-in help: `Get-Help .\WindowsUpdate-Manager_v2.ps1 -Full`
+- Built-in help: `Get-Help .\WindowsUpdate-Manager.ps1 -Full`
 - PSWindowsUpdate docs: https://www.powershellgallery.com/packages/PSWindowsUpdate
 
 ---
@@ -506,6 +530,6 @@ This script is provided "as-is" without warranty of any kind. Use at your own ri
 
 ---
 
-**Enjoy professional Windows Update management with WindowsUpdate-Manager v2!**
+**Enjoy professional Windows Update management with WindowsUpdate-Manager v3!**
 
 For questions or issues, please refer to the error logs or enable verbose mode for detailed diagnostics.

--- a/WindowsUpdate-Manager.ps1
+++ b/WindowsUpdate-Manager.ps1
@@ -1586,7 +1586,7 @@ function Action-ShowStatus {
         Write-ErrorLog $_
     }
 
-    Pause
+    Pause-UI
 }
 
 function Prompt-SearchFilters {
@@ -1674,7 +1674,7 @@ function Action-ScanUpdates {
     if ($mapped.Count -eq 0) {
       Write-Host ""
       Write-Success "No updates found. System is up to date!"
-      Pause
+      Pause-UI
       return
     }
 
@@ -1734,7 +1734,7 @@ function Action-ScanUpdates {
     Write-ErrorLog -Message "Update scan failed" -ErrorRecord $_
   } finally {
     Write-Progress -Activity "Scanning" -Completed
-    Pause
+    Pause-UI
   }
 }
 
@@ -1829,7 +1829,7 @@ function Action-InstallAll {
   $installCmd = Get-InstallCmd
   if (-not $installCmd) {
     Write-Err "Install-WindowsUpdate cmdlet not found. Try Update-WUModule or reinstall PSWindowsUpdate."
-    Pause
+    Pause-UI
     return
   }
 
@@ -1848,7 +1848,7 @@ function Action-InstallAll {
     Write-ErrorLog -Message "Install all failed" -ErrorRecord $_
   }
 
-  Pause
+  Pause-UI
 }
 
 function Action-InstallSelected {
@@ -1857,7 +1857,7 @@ function Action-InstallSelected {
   if (-not $script:LastScan -or $script:LastScan.Count -eq 0) {
     Write-Warning "No cached scan results found."
     Write-Info "Please run 'Scan for updates' first (Option 2)."
-    Pause
+    Pause-UI
     return
   }
 
@@ -1865,7 +1865,7 @@ function Action-InstallSelected {
 
   if (-not $selected -or $selected.Count -eq 0) {
     Write-Info "No updates selected."
-    Pause
+    Pause-UI
     return
   }
 
@@ -1921,7 +1921,7 @@ function Action-InstallSelected {
     Write-ErrorLog -Message "Install selected failed" -ErrorRecord $_
   }
 
-  Pause
+  Pause-UI
 }
 
 function Get-HideCmd {
@@ -1997,7 +1997,7 @@ function Action-HideSelected {
   if (-not $script:LastScan -or $script:LastScan.Count -eq 0) {
     Write-Warning "No cached scan results found."
     Write-Info "Please run 'Scan for updates' first (Option 2)."
-    Pause
+    Pause-UI
     return
   }
 
@@ -2005,7 +2005,7 @@ function Action-HideSelected {
 
   if (-not $selected -or $selected.Count -eq 0) {
     Write-Info "No updates selected."
-    Pause
+    Pause-UI
     return
   }
 
@@ -2044,7 +2044,7 @@ function Action-HideSelected {
     Write-ErrorLog -Message "Hide operation failed" -ErrorRecord $_
   }
 
-  Pause
+  Pause-UI
 }
 
 function Action-UnhideByKB {
@@ -2055,7 +2055,7 @@ function Action-UnhideByKB {
 
   if ([string]::IsNullOrWhiteSpace($kb)) {
     Write-Warning "No KB entered."
-    Pause
+    Pause-UI
     return
   }
 
@@ -2093,7 +2093,7 @@ function Action-UnhideByKB {
     Write-ErrorLog -Message "Unhide operation failed" -ErrorRecord $_
   }
 
-  Pause
+  Pause-UI
 }
 
 function Action-UninstallByKB {
@@ -2104,7 +2104,7 @@ function Action-UninstallByKB {
 
   if ([string]::IsNullOrWhiteSpace($kb)) {
     Write-Warning "No KB entered."
-    Pause
+    Pause-UI
     return
   }
 
@@ -2142,7 +2142,7 @@ function Action-UninstallByKB {
     Write-ErrorLog -Message "Uninstall operation failed" -ErrorRecord $_
   }
 
-  Pause
+  Pause-UI
 }
 
 function Action-History {
@@ -2172,7 +2172,7 @@ function Action-History {
     if ($historyArray.Count -eq 0) {
       Write-Host ""
       Write-Info "No history entries found."
-      Pause
+      Pause-UI
       return
     }
 
@@ -2210,7 +2210,7 @@ function Action-History {
     Write-Info "Note: Some environments have long history. If it hangs, limit with a number."
   } finally {
     Write-Progress -Activity "History" -Completed
-    Pause
+    Pause-UI
   }
 }
 
@@ -2252,7 +2252,7 @@ function Action-ResetWUComponents {
     Write-ErrorLog -Message "Component reset failed" -ErrorRecord $_
   }
 
-  Pause
+  Pause-UI
 }
 
 function Action-UpdateModule {
@@ -2288,7 +2288,7 @@ function Action-UpdateModule {
     Write-ErrorLog -Message "Module update failed" -ErrorRecord $_
   }
 
-  Pause
+  Pause-UI
 }
 
 function Action-Targets {
@@ -2335,7 +2335,7 @@ function Action-Targets {
     Write-Info "Targeting local computer only."
   }
 
-  Pause
+  Pause-UI
 }
 
 function Action-Settings {
@@ -2429,7 +2429,7 @@ function Toggle-Transcript {
 
     $script:TranscriptOn = $false
     Write-Success "Logging disabled."
-    Pause
+    Pause-UI
     return
   }
 
@@ -2452,7 +2452,7 @@ function Toggle-Transcript {
     Write-ErrorLog -Message "Transcript start failed" -ErrorRecord $_
   }
 
-  Pause
+  Pause-UI
 }
 
 function Manage-ExclusionList {
@@ -2547,7 +2547,7 @@ function Action-RemoteInstallJob {
 
   if ([string]::IsNullOrWhiteSpace($raw)) {
     Write-Warning "No targets specified."
-    Pause
+    Pause-UI
     return
   }
 
@@ -2613,7 +2613,7 @@ function Action-RemoteInstallJob {
     Write-Info "You can use Enable-WURemoting on remote computers."
   }
 
-  Pause
+  Pause-UI
 }
 
 function Action-ComplianceReport {
@@ -2702,7 +2702,7 @@ function Action-ComplianceReport {
     Write-ErrorLog -Message "Compliance report failed" -ErrorRecord $_
   }
 
-  Pause
+  Pause-UI
 }
 
 #endregion
@@ -2837,7 +2837,7 @@ function Main {
     if (-not (Initialize-Dependencies)) {
       Write-Err "Failed to initialize dependencies. Cannot continue."
       Write-Info "Error log: $($script:ErrorLogPath)"
-      Pause
+      Pause-UI
       exit 1
     }
 
@@ -2881,7 +2881,7 @@ function Main {
   } catch {
     Write-Err "Fatal error: $($_.Exception.Message)"
     Write-ErrorLog -Message "Fatal error" -ErrorRecord $_
-    Pause
+    Pause-UI
     exit 1
   } finally {
     # Cleanup
@@ -2922,11 +2922,6 @@ function Read-YesNo {
     return ($answer.Trim().ToLowerInvariant() -in @("y","yes"))
 }
 
-function Pause {
-    Write-Host ""
-    Write-Host "Press any key to continue..." -ForegroundColor Gray
-    $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
-}
 
 function Ensure-MicrosoftUpdateService {
     if ($script:Config.UseMicrosoftUpdate) {


### PR DESCRIPTION
Fixed code usages of `Pause` in `WindowsUpdate-Manager.ps1` changing them to use the defined function `Pause-UI`. Removed duplicate `Pause-UI` function. Corrected `README.md` and `USER_GUIDE.md` files to note Version 3 properly including visual notes.

---
*PR created automatically by Jules for task [4284120944198178170](https://jules.google.com/task/4284120944198178170) started by @GhostwheeI*